### PR TITLE
Code highlighting improvements

### DIFF
--- a/data/syntax/isocpp.xml
+++ b/data/syntax/isocpp.xml
@@ -787,7 +787,7 @@
       <itemData name="String"             defStyleNum="dsString"    spellChecking="true"  />
       <itemData name="String Char"        defStyleNum="dsSpecialChar" spellChecking="false" />
       <itemData name="Comment"            defStyleNum="dsComment"   spellChecking="true"  />
-      <itemData name="Symbol"             defStyleNum="dsNormal"    spellChecking="false" />
+      <itemData name="Symbol"             defStyleNum="dsOperator"    spellChecking="false" />
       <itemData name="Separator Symbol"   defStyleNum="dsNormal"    spellChecking="false" />
       <itemData name="Preprocessor"       defStyleNum="dsPreprocessor" spellChecking="false" />
       <itemData name="Prep. Lib"          defStyleNum="dsImport"    spellChecking="false" />

--- a/data/template/14882.css
+++ b/data/template/14882.css
@@ -259,14 +259,6 @@ code.itemdeclcode {
 	display: block;
 }
 
-code span.co { color: green; font-style: italic; font-family: serif; }
-code span.kw { color: #00607c; }
-code span.cf { color: #00607c; }
-code span.at { color: #00607c; }
-code span.dt { color: #00607c; }
-code span.op { color: #af1915; }
-code span.pp { color: #6F4E37; }
-
 span.textsuperscript {
 	vertical-align: super;
 	font-size: smaller;

--- a/data/template/14882.css
+++ b/data/template/14882.css
@@ -259,15 +259,13 @@ code.itemdeclcode {
 	display: block;
 }
 
-span.comment { color: green; font-style: italic; font-family: serif; }
-span.keyword { color: #00607c; }
-span.parenthesis { color: #af1915; }
-span.curlybracket { color: #af1915; }
-span.squarebracket { color: #af1915; }
-span.literal { color: #9F6807; }
-span.operator { color: #570057; }
-span.anglebracket { color: #570057; }
-span.preprocessordirective { color: #6F4E37; }
+code span.co { color: green; font-style: italic; font-family: serif; }
+code span.kw { color: #00607c; }
+code span.cf { color: #00607c; }
+code span.at { color: #00607c; }
+code span.dt { color: #00607c; }
+code span.op { color: #af1915; }
+code span.pp { color: #6F4E37; }
 
 span.textsuperscript {
 	vertical-align: super;


### PR DESCRIPTION
Change the syntax xml so that things like `strong_ordering` don't get parsed as having a global variable in the middle, highlight the keywords as keywords, and give a custom name to the brackets and operators so that they can be highlighted too.

Change the 14882.css so that it uses the same names that pandoc produces, and with enough specificity to override them. 