### PR TITLE
Use `=` for the binding pattern.

### DIFF
--- a/P1371R1.md
+++ b/P1371R1.md
@@ -724,7 +724,7 @@ inspect (v) {
 
 The binding pattern has the form:
 
-> | _identifier_ @ _pattern_
+> | _identifier_ = _pattern_
 
 and matches value `v` if _pattern_ matches it. The introduced name behaves as
 an lvalue referring to `v`, and is in scope from its point of declaration until
@@ -734,10 +734,15 @@ the end of the statement following the pattern label.
 std::variant<Point, /* ... */> v = /* ... */;
 
 inspect (v) {
-    <Point> (p @ [x, y]): // ...
+    <Point> (p = [x, y]): // ...
 //           ^^^^^^^^^^ binding pattern
 }
 ```
+
+Previous versions of this paper used `@` for the binding pattern. EWG gave clear
+feedback that this wouldn't be accepted, and voiced a preference for `=` which
+we have duly adopted. We also considered `%`, `$`, `:=`, `as` and `by` as
+potential alternatives.
 
 #### Dereference Pattern
 


### PR DESCRIPTION
Also namedrop the alternatives.