### PR TITLE
Changing div.marginalizedparent to span.marginalizedparent

### DIFF
--- a/data/filter/wg21.py
+++ b/data/filter/wg21.py
@@ -92,10 +92,9 @@ def divspan(elem, doc):
             return pf.RawInline('\\pnum{{{}}}'.format(num), 'latex')
 
         if doc.format == 'html':
-            return pf.RawInline(
-                '<span class="marginalizedparent">' \
-                    '<a class="marginalized">{}</a>' \
-                '</span>'.format(num), 'html')
+            return pf.Span(
+                pf.RawInline('<a class="marginalized">{}</a>'.format(num), 'html')
+                classes=['marginalizedparent'])
 
         return pf.Superscript(pf.Str(num))
 

--- a/data/filter/wg21.py
+++ b/data/filter/wg21.py
@@ -93,9 +93,9 @@ def divspan(elem, doc):
 
         if doc.format == 'html':
             return pf.RawInline(
-                '<div class="marginalizedparent">' \
+                '<span class="marginalizedparent">' \
                     '<a class="marginalized">{}</a>' \
-                '</div>'.format(num), 'html')
+                '</span>'.format(num), 'html')
 
         return pf.Superscript(pf.Str(num))
 

--- a/data/template/14882.css
+++ b/data/template/14882.css
@@ -83,15 +83,15 @@ a.itemDeclLink {
 }
 a.itemDeclLink:hover { opacity: 1; }
 
-.marginalizedparent {
+span.marginalizedparent {
 	position: relative;
 	left: -5em;
 }
 
-li > .marginalizedparent { left: -7em; }
-li > ul > li > .marginalizedparent { left: -9em; }
-li > ul > li > ul > li > .marginalizedparent { left: -11em; }
-li > ul > li > ul > li > ul > li > .marginalizedparent { left: -13em; }
+li > span.marginalizedparent { left: -7em; }
+li > ul > li > span.marginalizedparent { left: -9em; }
+li > ul > li > ul > li > span.marginalizedparent { left: -11em; }
+li > ul > li > ul > li > ul > li > span.marginalizedparent { left: -13em; }
 
 div.footnoteNumberParent {
 	position: relative;

--- a/data/template/14882.css
+++ b/data/template/14882.css
@@ -83,15 +83,15 @@ a.itemDeclLink {
 }
 a.itemDeclLink:hover { opacity: 1; }
 
-div.marginalizedparent {
+.marginalizedparent {
 	position: relative;
 	left: -5em;
 }
 
-li > div.marginalizedparent { left: -7em; }
-li > ul > li > div.marginalizedparent { left: -9em; }
-li > ul > li > ul > li > div.marginalizedparent { left: -11em; }
-li > ul > li > ul > li > ul > li > div.marginalizedparent { left: -13em; }
+li > .marginalizedparent { left: -7em; }
+li > ul > li > .marginalizedparent { left: -9em; }
+li > ul > li > ul > li > .marginalizedparent { left: -11em; }
+li > ul > li > ul > li > ul > li > .marginalizedparent { left: -13em; }
 
 div.footnoteNumberParent {
 	position: relative;


### PR DESCRIPTION
I believe all the uses of marginalizedparent were the inline ones introduced by `{.pnum}`, so this is my attent at fixing #33. It appears to work for my use-case at least.  