### PR TITLE
Order-only dependency on output.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,7 @@ $(if $(filter %.html, $@),
 $(CMD)
 endef
 
-override DEPS := $(OUTDIR)
-override DEPS += $(addprefix $(DATADIR)/, defaults.yaml index.yaml annex-f)
+override DEPS := $(addprefix $(DATADIR)/, defaults.yaml index.yaml annex-f)
 $(eval $(and $(DEFAULTS), override DEPS += $(DEFAULTS)))
 $(eval $(and $(METADATA), override DEPS += $(METADATA)))
 
@@ -56,6 +55,6 @@ $(DATADIR)/index.yaml:
 $(DATADIR)/annex-f:
 	wget https://timsong-cpp.github.io/cppwp/annex-f -O $@
 
-$(OUTDIR)/%.html $(OUTDIR)/%.latex $(OUTDIR)/%.pdf: $(DEPS) $(SRCDIR)/%.md
+$(OUTDIR)/%.html $(OUTDIR)/%.latex $(OUTDIR)/%.pdf: $(DEPS) $(SRCDIR)/%.md | $(OUTDIR)
 	$(PANDOC) \
     --bibliography $(DATADIR)/index.yaml


### PR DESCRIPTION
If the `OUTDIR` is a normal dependency and I'm building multiple papers into the same directory, then touching anything means rebuilding everything. The `OUTDIR` just needs to be created by this step, it doesn't need to trigger rebuilds.