### PR TITLE
Update design wording for expression-only inspect

### DIFF
--- a/D1371R3.md
+++ b/D1371R3.md
@@ -403,8 +403,7 @@ expression evaluates to `false`, control flows to the subsequent pattern.
 If no pattern matches, none of the expressions or compound statements specified
 are executed. In that case if the `inspect` expression yields `void`, control is
 passed to the next statement. If the `inspect` expression does not yield void,
-the behavior is undefined. Additionally, if a `:` clause of the `inspect`
-expression does not stop execution of the function, the behaviour is undefined.
+the behavior is undefined.
 
 \pagebreak
 

--- a/D1371R3.md
+++ b/D1371R3.md
@@ -371,7 +371,7 @@ Op parseOp(Parser& parser) {
 
 > | `inspect constexpr`*~opt~* `(` *init-statement~opt~* *condition* `)` *trailing-return-type~opt~* `{`
 > |     *pattern* *guard~opt~* `:` *expression* `,`
-> |     *pattern* *guard~opt~* `:` `{` *statement-seq* `}`
+> |     *pattern* *guard~opt~* `:` `!`*~opt~* `{` *statement-seq* `}`
 > |     ...
 > | `}`
 
@@ -386,13 +386,12 @@ of its condition.
 
 `inspect` is an expression in all contexts. Depending on the enclosed patterns it
 may either yield a `void` result or a value, the type of which will be statically
-deduced from the trailing return type or the patterns themselves. This deduction
-is analogous to that performed when determining the return type of a lambda
-expression. An `inspect` expression yields a `void` result if one or more of
-the enclosed patterns passes control to a compound statement. The return types
-of all patterns must match. If a trailing return type is provided, all patterns
-must result in an expression returning a type that is implicitly convertible
-to the trailing return type.
+deduced from the patterns themselves or specified by a trailing return type. The
+deduction is analogous to that performed when determining the return type of a
+lambda expression. A pattern that passes control to a compound statement yields
+a `void` result. The return types of all patterns must match. If a trailing return
+type is provided, all patterns must result in an expression returning a type that
+is implicitly convertible to the trailing return type.
 
 When `inspect` is executed, its condition is evaluated and matched
 in order (first match semantics) against each pattern. If a pattern successfully

--- a/D1371R3.md
+++ b/D1371R3.md
@@ -68,10 +68,9 @@ the "vocabulary types" provided by the standard library.
 In C++17, structured binding declarations [@P0144R2] introduced the ability to
 concisely bind names to components of `tuple`-like values. The proposed
 direction of this paper aims to naturally extend this notion by performing
-__structured inspection__  with `inspect` statements and expressions. The
-goal of `inspect` is to bridge the gap between `switch` and `if` statements
-with a __declarative__, __structured__, __cohesive__, and __composable__
-mechanism.
+__structured inspection__  with `inspect` expressions. The goal of `inspect`
+is to bridge the gap between `switch` and `if` statements with a
+__declarative__, __structured__, __cohesive__, and __composable__ mechanism.
 
 \pagebreak
 
@@ -371,8 +370,8 @@ Op parseOp(Parser& parser) {
 ## Basic Syntax
 
 > | `inspect constexpr`*~opt~* `(` *init-statement~opt~* *condition* `)` *trailing-return-type~opt~* `{`
-> |     *pattern* *guard~opt~* `=>` *expression* `,`
-> |     *pattern* *guard~opt~* `:` *statement*
+> |     *pattern* *guard~opt~* `:` *expression* `,`
+> |     *pattern* *guard~opt~* `:` `{` *statement-seq* `}`
 > |     ...
 > | `}`
 
@@ -385,29 +384,28 @@ Within the parentheses, `inspect` is equivalent to `switch` and `if` statements
 except that no conversion nor promotion takes place in evaluating the value
 of its condition.
 
-There are two clause variations types inside the `inspect` body:
-
-  - `=>` denotes expression yielding a value.
-  - `:` never yields a value, but instead denotes a statement that is executed
-    in the enclosing context. e.g, a `return` statement will return from the
-    function `inspect` is currently running in.
-
-`inspect` is an expression if it's encountered in an expression-only context,
-`trailing-return-type` is specified, or any `=>` clauses are present.
-It's a statement otherwise.
+`inspect` is an expression in all contexts. Depending on the enclosed patterns it
+may either yield a `void` result or a value, the type of which will be statically
+deduced from the trailing return type or the patterns themselves. This deduction
+is analogous to that performed when determining the return type of a lambda
+expression. An `inspect` expression yields a `void` result if one or more of
+the enclosed patterns passes control to a compound statement. The return types
+of all patterns must match. If a trailing return type is provided, all patterns
+must result in an expression returning a type that is implicitly convertible
+to the trailing return type.
 
 When `inspect` is executed, its condition is evaluated and matched
 in order (first match semantics) against each pattern. If a pattern successfully
 matches the value of the condition and the boolean expression in the guard
 evaluates to `true` (or if there is no guard at all), control is passed to the
-statement or expression following the matched pattern label. If the guard
+expression or compound statement following the matched pattern label. If the guard
 expression evaluates to `false`, control flows to the subsequent pattern.
 
-If no pattern matches, none of the statements or expressions specified are executed.
-In that case, if `inspect` is a statment - control is passed to the next statement.
-If it's an expression, the behavor is undefined. Additionally, if a `:` clause of
-the `inspect` expression does not stop execution of the function, the behaviour is
-undefined.
+If no pattern matches, none of the expressions or compound statements specified
+are executed. In that case if the `inspect` expression yields `void`, control is
+passed to the next statement. If the `inspect` expression does not yield void,
+the behavior is undefined. Additionally, if a `:` clause of the `inspect`
+expression does not stop execution of the function, the behaviour is undefined.
 
 \pagebreak
 

--- a/D1371R3.md
+++ b/D1371R3.md
@@ -92,9 +92,9 @@ switch (x) {
 ### After
 ```cpp
 inspect (x) {
-  0: std::cout << "got zero";
-  1: std::cout << "got one";
-  __: std::cout << "don't care";
+  0 => std::cout << "got zero";
+  1 => std::cout << "got one";
+  __ => std::cout << "don't care";
 }
 ```
 
@@ -118,9 +118,9 @@ if (s == "foo") {
 ### After
 ```cpp
 inspect (s) {
-  "foo": std::cout << "got foo";
-  "bar": std::cout << "got bar";
-  __: std::cout << "don't care";
+  "foo" => std::cout << "got foo";
+  "bar" => std::cout << "got bar";
+  __ => std::cout << "don't care";
 }
 ```
 
@@ -147,10 +147,10 @@ if (x == 0 && y == 0) {
 ### After
 ```cpp
 inspect (p) {
-  [0, 0]: std::cout << "on origin";
-  [0, y]: std::cout << "on y-axis";
-  [x, 0]: std::cout << "on x-axis";
-  [x, y]: std::cout << x << ',' << y;
+  [0, 0] => std::cout << "on origin";
+  [0, y] => std::cout << "on y-axis";
+  [x, 0] => std::cout << "on x-axis";
+  [x, y] => std::cout << x << ',' << y;
 }
 ```
 
@@ -179,8 +179,8 @@ std::visit(visitor{strm}, v);
 ### After
 ```cpp
 inspect (v) {
-  <int> i: strm << "got int: " << i;
-  <float> f: strm << "got float: " << f;
+  <int> i => strm << "got int: " << i;
+  <float> f => strm << "got float: " << f;
 }
 ```
 
@@ -353,7 +353,7 @@ Op parseOp(Parser& parser) {
     '-' => Op::Sub,
     '*' => Op::Mul,
     '/' => Op::Div,
-    token: {
+    token => {
       std::cerr << "Unexpected: " << token;
       std::terminate();
     }
@@ -370,8 +370,8 @@ Op parseOp(Parser& parser) {
 ## Basic Syntax
 
 > | `inspect constexpr`*~opt~* `(` *init-statement~opt~* *condition* `)` *trailing-return-type~opt~* `{`
-> |     *pattern* *guard~opt~* `:` *statement*
-> |     *pattern* *guard~opt~* `:` `!`*~opt~* `{` *statement-seq* `}`
+> |     *pattern* *guard~opt~* `=>` *statement*
+> |     *pattern* *guard~opt~* `=>` `!`*~opt~* `{` *statement-seq* `}`
 > |     ...
 > | `}`
 
@@ -424,7 +424,7 @@ and matches any value `v`.
 int v = /* ... */;
 
 inspect (v) {
-    __: std::cout << "ignored";
+    __ => std::cout << "ignored";
 //  ^^ wildcard pattern
 }
 ```
@@ -448,7 +448,7 @@ the end of the statement following the pattern label.
 int v = /* ... */;
 
 inspect (v) {
-    x: std::cout << x;
+    x => std::cout << x;
 //  ^ identifier pattern
 }
 ```
@@ -472,8 +472,8 @@ The default behavior of `match(x, y)` is `x == y`.
 int v = /* ... */;
 
 inspect (v) {
-    0: std::cout << "got zero";
-    1: std::cout << "got one";
+    0 => std::cout << "got zero";
+    1 => std::cout << "got one";
 //  ^ expression pattern
 }
 ```
@@ -483,9 +483,9 @@ enum class Color { Red, Green, Blue };
 Color color = /* ... */;
 
 inspect (color) {
-    Color::Red:   // ...
-    Color::Green: // ...
-    Color::Blue:  // ...
+    Color::Red =>   // ...
+    Color::Green => // ...
+    Color::Blue =>  // ...
 //  ^^^^^^^^^^^ expression pattern
 }
 ```
@@ -498,7 +498,7 @@ static constexpr int zero = 0, one = 1;
 int v = 42;
 
 inspect (v) {
-    zero: std::cout << zero;
+    zero => std::cout << zero;
 //  ^^^^ identifier pattern
 }
 
@@ -523,12 +523,12 @@ declaration: `auto&& [__e`~0~`, __e`~1~`,` ...`, __e`~N~`] = v;` where each
 std::pair<int, int> p = /* ... */;
 
 inspect (p) {
-    [0, 0]: std::cout << "on origin";
-    [0, y]: std::cout << "on y-axis";
+    [0, 0] => std::cout << "on origin";
+    [0, y] => std::cout << "on y-axis";
 //      ^ identifier pattern
-    [x, 0]: std::cout << "on x-axis";
+    [x, 0] => std::cout << "on x-axis";
 //      ^ expression pattern
-    [x, y]: std::cout << x << ',' << y;
+    [x, y] => std::cout << x << ',' << y;
 //  ^^^^^^ structured binding pattern
 }
 ```
@@ -545,11 +545,11 @@ struct Player { std::string name; int hitpoints; int coins; };
 
 void get_hint(const Player& p) {
     inspect (p) {
-        [.hitpoints: 1]: std::cout << "You're almost destroyed. Give up!\n";
-        [.hitpoints: 10, .coins: 10]: std::cout << "I need the hints from you!\n";
-        [.coins: 10]: std::cout << "Get more hitpoints!\n";
-        [.hitpoints: 10]: std::cout << "Get more ammo!\n";
-        [.name: n]: {
+        [.hitpoints: 1] => { std::cout << "You're almost destroyed. Give up!\n"; }
+        [.hitpoints: 10, .coins: 10] => { std::cout << "I need the hints from you!\n"; }
+        [.coins: 10] => { std::cout << "Get more hitpoints!\n"; }
+        [.hitpoints: 10] => { std::cout << "Get more ammo!\n"; }
+        [.name: n] => {
             if (n != "The Bruce Dickenson") {
                 std::cout << "Get more hitpoints and ammo!\n";
             } else {
@@ -605,7 +605,7 @@ std::visit([&](auto&& x) {
 ### After {width=.47}
 ```cpp
 inspect (v) {
-  <auto> x: strm << "got auto: " << x;
+  <auto> x => strm << "got auto: " << x;
 }
 ```
 
@@ -624,8 +624,8 @@ std::visit([&](auto&& x) {
 
 ```cpp
 inspect (v) {
-  <C1> c1: strm << "got C1: " << c1;
-  <C2> c2: strm << "got C2: " << c2;
+  <C1> c1 => strm << "got C1: " << c1;
+  <C2> c2 => strm << "got C2: " << c2;
 }
 ```
 
@@ -645,8 +645,8 @@ std::visit([&](auto&& x) {
 
 ```cpp
 inspect (v) {
-  <int> i: strm << "got int: " << i;
-  <float> f: strm << "got float: " << f;
+  <int> i => strm << "got int: " << i;
+  <float> f => strm << "got float: " << f;
 }
 ```
 
@@ -664,7 +664,7 @@ std::visit([&](int x) {
 std::variant<int, int> v = /* ... */;
 
 inspect (v) {
-  <int> x: strm << "got int: " << x;
+  <int> x => strm << "got int: " << x;
 }
 ```
 
@@ -689,8 +689,8 @@ std::visit([&](auto&& x) {
 std::variant<int, int> v = /* ... */;
 
 inspect (v) {
-  <0> x: strm << "got first: " << x;
-  <1> x: strm << "got second: " << x;
+  <0> x => strm << "got first: " << x;
+  <1> x => strm << "got second: " << x;
 }
 ```
 
@@ -725,8 +725,8 @@ if (int* i = any_cast<int>(&a)) {
 std::any a = 42;
 
 inspect (a) {
-  <int> i: std::cout << "got int: " << i;
-  <float> f: std::cout << "got float: " << f;
+  <int> i => std::cout << "got int: " << i;
+  <float> f => std::cout << "got float: " << f;
 }
 ```
 
@@ -774,8 +774,8 @@ int Rectangle::get_area() const override {
 ```cpp
 int get_area(const Shape& shape) {
   inspect (shape) {
-    <Circle> [r]: return 3.14 * r * r;
-    <Rectangle> [w, h]: return w * h;
+    <Circle> [r] => return 3.14 * r * r;
+    <Rectangle> [w, h] => return w * h;
   }
 }
 ```
@@ -796,7 +796,7 @@ and matches value `v` if _pattern_ matches `v`.
 std::variant<Point, /* ... */> v = /* ... */;
 
 inspect (v) {
-    <Point> ([x, y]): // ...
+    <Point> ([x, y]) => // ...
 //          ^^^^^^^^ parenthesized pattern
 }
 ```
@@ -818,10 +818,10 @@ enum Color { Red, Green, Blue };
 Color color = /* ... */;
 
 inspect (color) {
-    case Red:   // ...
-    case Green: // ...
+    case Red =>   // ...
+    case Green => // ...
 //       ^^^^^ id-expression
-    case Blue:  // ...
+    case Blue =>  // ...
 //  ^^^^^^^^^ case pattern
 }
 ```
@@ -831,11 +831,11 @@ static constexpr int zero = 0;
 int v = /* ... */;
 
 inspect (v) {
-    case zero: std::cout << "got zero";
+    case zero => std::cout << "got zero";
 //       ^^^^ id-expression
-    case 1: std::cout << "got one";
+    case 1 => std::cout << "got one";
 //       ^ expression pattern
-    case 2: std::cout << "got two";
+    case 2 => std::cout << "got two";
 //  ^^^^^^ case pattern
 }
 ```
@@ -847,7 +847,7 @@ static constexpr int zero = 0, one = 1;
 std::pair<int, int> p = /* ... */
 
 inspect (p) {
-    case [zero, one]: {
+    case [zero, one] => {
 //        ^^^^  ^^^ id-expression
       std::cout << zero << ' ' << one;
 //    Note that    ^^^^ and       ^^^ are id-expressions
@@ -878,7 +878,7 @@ then _id-expression_s.
 int v = /* ... */;
 
 inspect (v) {
-    /* let */ x: std::cout << x;
+    /* let */ x => std::cout << x;
 //            ^ identifier pattern
 }
 ```
@@ -888,11 +888,11 @@ static constexpr int two = 2;
 int v = 42;
 
 inspect (v) {
-    let 0: std::cout << "got zero";
+    let 0 => std::cout << "got zero";
 //      ^ expression pattern
-    let 1: std::cout << "got one";
+    let 1 => std::cout << "got one";
 //  ^^^^^ let pattern
-    let two: std::cout << two;
+    let two => std::cout << two;
 //      ^^^ identifier pattern
 }
 
@@ -906,9 +906,9 @@ static constexpr int zero = 0, one = 1;
 std::pair<int, std::pair<int, int>> p = /* ... */
 
 inspect (p) {
-    case [zero, let [x, y]]: std::cout << "got zero" << ' ' << x << ' ' << y;
+    case [zero, let [x, y]] => std::cout << "got zero" << ' ' << x << ' ' << y;
 //                   ^  ^ identifier pattern
-    case [one, let [x, y]]: std::cout << "got one" << ' ' << x << ' ' << y;
+    case [one, let [x, y]] => std::cout << "got one" << ' ' << x << ' ' << y;
 //             ^^^^^^^^^^  binding pattern
 }
 ```
@@ -917,7 +917,7 @@ inspect (p) {
 std::variant<Point, /* ... */> v = /* ... */;
 
 inspect (v) {
-    <Point> (let p = [x, y]): // ...
+    <Point> (let p = [x, y]) => // ...
 //           ^^^^^^^^^^^^^^ binding pattern
 }
 ```
@@ -941,8 +941,8 @@ struct Node {
 
 void print_leftmost(const Node& node) {
     inspect (node) {
-        [.value: v, .lhs: nullptr]: std::cout << v << '\n';
-        [.lhs: (*!) l]: print_leftmost(l);
+        [.value: v, .lhs: nullptr] => { std::cout << v << '\n'; }
+        [.lhs: (*!) l] => { print_leftmost(l); }
 //             ^^^^ dereference pattern
     }
 }
@@ -978,7 +978,7 @@ inline constexpr Is<T> is;
 
 // P0480: `auto&& [std::string s, int i] = f();`
 inspect (f()) {
-    [(is<std::string>!) s, (is<int>!) i]: // ...
+    [(is<std::string>!) s, (is<int>!) i] => // ...
 //   ^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^ extractor pattern
 }
 ```
@@ -1004,8 +1004,8 @@ struct PhoneNumber {
 inline constexpr PhoneNumber phone_number;
 
 inspect (s) {
-    (email?) [address, domain]: std::cout << "got an email";
-    (phone_number?) ["415", __, __]: std::cout << "got a San Francisco phone number";
+    (email?) [address, domain] => std::cout << "got an email";
+    (phone_number?) ["415", __, __] => std::cout << "got a San Francisco phone number";
 //  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ extractor pattern
 }
 ```
@@ -1025,7 +1025,7 @@ within the _pattern_. For example, performing tests across multiple bindings:
 
 ```cpp
 inspect (p) {
-    [x, y] if (test(x, y)): std::cout << x << ',' << y << " passed";
+    [x, y] if (test(x, y)) => std::cout << x << ',' << y << " passed";
 //         ^^^^^^^^^^^^^^^ pattern guard
 }
 ```
@@ -1045,8 +1045,8 @@ able to perform the following transformation:
 ### `inspect` {width=.4}
 ```cpp
 inspect (v) {
-  pattern1 if (cond1): stmt1
-  pattern2: stmt2
+  pattern1 if (cond1) => { stmt1 }
+  pattern2 => { stmt2 }
   // ...
 }
 ```
@@ -1067,8 +1067,8 @@ else if (MATCHES(pattern2, v)) stmt2
 ### `inspect constexpr` {width=.4}
 ```cpp
 inspect constexpr (v) {
-  pattern1 if (cond1): stmt1
-  pattern2: stmt2
+  pattern1 if (cond1) => { stmt1 }
+  pattern2 => { stmt2 }
   // ...
 }
 ```
@@ -1145,7 +1145,7 @@ Add to __§8.4 [stmt.select]__ of ...
 > |     *inspect-expression-case-seq* `,` *inspect-expression-case*
 >
 > | *inspect-statement-case:*
-> |     *inspect-pattern* *inspect-guard~opt~* `:` *statement*
+> |     *inspect-pattern* *inspect-guard~opt~* `=>` *statement*
 >
 > | *inspect-expression-case:*
 > |     *inspect-pattern* *inspect-guard~opt~* `=>` *assignment-expression*
@@ -1252,9 +1252,9 @@ bool f(int &);  // defined in a different translation unit.
 int x = 1;
 
 inspect (x) {
-  0: std::cout << 0;
-  1 if (f(x)): std::cout << 1;
-  2: std::cout << 2;
+  0 => std::cout << 0;
+  1 if (f(x)) => std::cout << 1;
+  2 => std::cout << 2;
 }
 ```
 
@@ -1443,8 +1443,8 @@ namespace std {
 
 char* String::data() {
   inspect (*this) {
-    <Local> l: return l;
-    <Remote> r: return r.ptr;
+    <Local> l => return l;
+    <Remote> r => return r.ptr;
   }
   // switch (index()) {
   //   case Local: {
@@ -1504,8 +1504,8 @@ auto&& get(const Shape& shape) {
 
 int get_area(const Shape& shape) {
   inspect (shape) {
-    <Circle> c: return 3.14 * c.radius * c.radius;
-    <Rectangle> r: return r.width * r.height;
+    <Circle> c => return 3.14 * c.radius * c.radius;
+    <Rectangle> r => return r.width * r.height;
   }
   // switch (index(shape)) {
   //   case Shape::Circle: {
@@ -1547,9 +1547,9 @@ struct any_of : std::tuple<Ts...> {
 ```cpp
 int fib(int n) {
   inspect (n) {
-    x if (x < 0): return 0;
-    any_of{1, 2}: return n;  // 1 | 2
-    x: return fib(x - 1) + fib(x - 2);
+    x if (x < 0) => return 0;
+    any_of{1, 2} => return n;  // 1 | 2
+    x => return fib(x - 1) + fib(x - 2);
   }
 }
 ```
@@ -1569,10 +1569,10 @@ struct within {
 
 ```cpp
 inspect (n) {
-  within{1, 10}: {  // 1..10
+  within{1, 10} => {  // 1..10
     std::cout << n << " is in [1, 10].";
   }
-  __: {
+  __ => {
     std::cout << n << " is not in [1, 10].";
   }
 }
@@ -1602,7 +1602,7 @@ inline constexpr Both both;
 
 ```cpp
 inspect (v) {
-  (both!) [[x, 0], [0, y]]: // ...
+  (both!) [[x, 0], [0, y]] => // ...
 }
 ```
 
@@ -1621,7 +1621,7 @@ inline constexpr at = both;
 
 ```cpp
 inspect (v) {
-  <Point> (at!) [p, [x, y]]: // ...
+  <Point> (at!) [p, [x, y]] => // ...
   // ...
 }
 ```
@@ -1768,8 +1768,8 @@ alternative to support pattern matching.
 U u = /* ... */;
 
 inspect (u) {
-  <U::small> s: std::cout << s;
-  <U::big> b: std::cout << b;
+  <U::small> s => std::cout << s;
+  <U::big> b => std::cout << b;
 }
 ```
 

--- a/D1371R3.md
+++ b/D1371R3.md
@@ -370,7 +370,7 @@ Op parseOp(Parser& parser) {
 ## Basic Syntax
 
 > | `inspect constexpr`*~opt~* `(` *init-statement~opt~* *condition* `)` *trailing-return-type~opt~* `{`
-> |     *pattern* *guard~opt~* `:` *expression* `,`
+> |     *pattern* *guard~opt~* `:` *statement*
 > |     *pattern* *guard~opt~* `:` `!`*~opt~* `{` *statement-seq* `}`
 > |     ...
 > | `}`
@@ -384,9 +384,9 @@ Within the parentheses, `inspect` is equivalent to `switch` and `if` statements
 except that no conversion nor promotion takes place in evaluating the value
 of its condition.
 
-`inspect` is an expression in all contexts. Depending on the enclosed patterns it
+`inspect` is an expression in all contexts. Depending on the enclosed statements it
 may either yield a `void` result or a value, the type of which will be statically
-deduced from the patterns themselves or specified by a trailing return type. The
+deduced from the statements themselves or specified by a trailing return type. The
 deduction is analogous to that performed when determining the return type of a
 lambda expression. A pattern that passes control to a compound statement yields
 a `void` result. The return types of all patterns must match. If a trailing return
@@ -396,14 +396,15 @@ is implicitly convertible to the trailing return type.
 When `inspect` is executed, its condition is evaluated and matched
 in order (first match semantics) against each pattern. If a pattern successfully
 matches the value of the condition and the boolean expression in the guard
-evaluates to `true` (or if there is no guard at all), control is passed to the
-expression or compound statement following the matched pattern label. If the guard
+evaluates to `true` (or if there is no guard at all), then the value of the
+resulting expression is yielded or control is passed to the compound statement,
+depending on whether the inspect yields a value. If the guard
 expression evaluates to `false`, control flows to the subsequent pattern.
 
 If no pattern matches, none of the expressions or compound statements specified
 are executed. In that case if the `inspect` expression yields `void`, control is
-passed to the next statement. If the `inspect` expression does not yield void,
-the behavior is undefined.
+passed to the next statement. If the `inspect` expression does not yield `void`,
+`std::terminate` will be called.
 
 \pagebreak
 


### PR DESCRIPTION
* Inspect is an expression in all contexts
* This invalidates several examples