### PR TITLE
D2211R0: Update paper to latest syntax

### DIFF
--- a/D2211R0.md
+++ b/D2211R0.md
@@ -35,14 +35,14 @@ enum Color { Red, Green, Blue };
 //...
 Color c = /*...*/;
 vec3 v = inspect(c) {                 // ERROR: Missing case 'Blue'
-  case Red   => vec3(1.0, 0.0, 0.0),
-  case Green => vec3(0.0, 1.0, 0.0),
+  case Red   => vec3(1.0, 0.0, 0.0);
+  case Green => vec3(0.0, 1.0, 0.0);
 };
 
 vec3 v2 = inspect(c) {                // OKAY
-  case Red   => vec3(1.0, 0.0, 0.0),
-  case Green => vec3(0.0, 1.0, 0.0),
-  case Blue  => vec3(0.0, 0.0, 1.0),
+  case Red   => vec3(1.0, 0.0, 0.0);
+  case Green => vec3(0.0, 1.0, 0.0);
+  case Blue  => vec3(0.0, 0.0, 1.0);
 };
 ```
 
@@ -68,17 +68,17 @@ get back to this later.
 
 ```C++
 inspect(i) {
-  1  => std::cout << "one",
-  2  => std::cout << "two",
-  __ => std::cout << "something else",
+  1  => std::cout << "one";
+  2  => std::cout << "two";
+  __ => std::cout << "something else";
 }
 ```
 
 ```C++
 inspect(i) {
-  1 => std::cout << "one",
-  2 => std::cout << "two",
-  x => std::cout << x,
+  1 => std::cout << "one";
+  2 => std::cout << "two";
+  x => std::cout << x;
 }
 ```
 
@@ -88,8 +88,8 @@ struct Point { int xCoordinate; int yCoordinate; }
 struct Box { Point topLeft; int width; int height };
 
 inspect(box) {
-  [tl, w, h] => /*...*/,
-  [[x,y], w, h] => /*...*/
+  [tl, w, h] => /*...*/;
+  [[x,y], w, h] => /*...*/;
 }
 ```
 
@@ -107,13 +107,13 @@ char const * const str = inspect(b) { true => "true" }; // ERROR: missing
 ```c++
 bool b = /*...*/;
 char const * const str = inspect(b) {
-  true => "true",
-  false => "false"                    // OKAY, pattern exhaustive
+  true => "true";
+  false => "false";                   // OKAY, pattern exhaustive
 };
 
 char const * const str = inspect(b) {
-  true => "true",
-  __   => "false"                     // OKAY, pattern exhaustive
+  true => "true";
+  __   => "false";                    // OKAY, pattern exhaustive
 };
 ```
 
@@ -124,16 +124,16 @@ enum Color { Red, Green, Blue };
 //...
 Color c = /*...*/;
 vec3 v = inspect(c) {                 // ERROR: Missing case 'Blue'
-  case Red   => vec3(1.0, 0.0, 0.0),
-  case Green => vec3(0.0, 1.0, 0.0),
+  case Red   => vec3(1.0, 0.0, 0.0);
+  case Green => vec3(0.0, 1.0, 0.0);
 };
 ```
 
 ```C++
 vec3 v = inspect(c) {                // OKAY
-  case Red   => vec3(1.0, 0.0, 0.0),
-  case Green => vec3(0.0, 1.0, 0.0),
-  case Blue  => vec3(0.0, 0.0, 1.0),
+  case Red   => vec3(1.0, 0.0, 0.0);
+  case Green => vec3(0.0, 1.0, 0.0);
+  case Blue  => vec3(0.0, 0.0, 1.0);
 };
 ```
 
@@ -141,9 +141,9 @@ vec3 v = inspect(c) {                // OKAY
 Color val_outside_enumerators = static_cast<Color>(3);
 
 vec3 v = inspect(val_outside_enumerators) {     // 'std::terminate' at runtime
-  case Red   => vec3(1.0, 0.0, 0.0),
-  case Green => vec3(0.0, 1.0, 0.0),
-  case Blue  => vec3(0.0, 0.0, 1.0),
+  case Red   => vec3(1.0, 0.0, 0.0);
+  case Green => vec3(0.0, 1.0, 0.0);
+  case Blue  => vec3(0.0, 0.0, 1.0);
 };
 ```
 
@@ -151,10 +151,10 @@ vec3 v = inspect(val_outside_enumerators) {     // 'std::terminate' at runtime
 Color val_outside_enumerators = static_cast<Color>(3);
 
 vec3 v = inspect(val_outside_enumerators) {     // Throw exception at runtime
-  case Red   => vec3(1.0, 0.0, 0.0),
-  case Green => vec3(0.0, 1.0, 0.0),
-  case Blue  => vec3(0.0, 0.0, 1.0),
-  __         => throw Up{},
+  case Red   => vec3(1.0, 0.0, 0.0);
+  case Green => vec3(0.0, 1.0, 0.0);
+  case Blue  => vec3(0.0, 0.0, 1.0);
+  __         => !{ throw Up{} };
 };
 ```
 
@@ -173,9 +173,9 @@ struct FlagsV1 {
 
 ```C++
 inspect(flagsV1) {
-  [false, false] => /*...*/,
-  [true , false] => /*...*/,
-  [_    , true ] => /*...*/,
+  [false, false] => /*...*/;
+  [true , false] => /*...*/;
+  [_    , true ] => /*...*/;
 };
 ```
 
@@ -192,9 +192,9 @@ struct FlagsV2 {
 constexpr auto allFalse = FlagsV2{ .firstFlag=false,
                                    .secondFlag=false };
 inspect(flagsV2) {
-  case allFalse  => /*...*/,
-  [false, false] => /*...*/,
-  [_    , true ] => /*...*/,
+  case allFalse  => /*...*/;
+  [false, false] => /*...*/;
+  [_    , true ] => /*...*/;
 };
 ```
 
@@ -214,9 +214,9 @@ struct FlagsV3 {
 constexpr auto allFalse = FlagsV3{ .firstFlag=false,
                                    .secondFlag=false };
 inspect(flagsV3) {
-  case allFalse  => /*...*/,
-  [false, false] => /*...*/,
-  [_    , true ] => /*...*/,  // ERROR: {false, false} case not handled.
+  case allFalse  => /*...*/;
+  [false, false] => /*...*/;
+  [_    , true ] => /*...*/;  // ERROR: {false, false} case not handled.
 };
 ```
 
@@ -241,8 +241,8 @@ using Command = std::variant<FireBlasters, Move>;
 ```c++
 std::string cmdToStringV1(Command cmd) {
   return inspect(cmd) {
-    <FireBlasters> [i] => std::format("Fire Blasters with power {}", i),
-    <Move> [case Left] => std::string("Move Left"),
+    <FireBlasters> [i] => std::format("Fire Blasters with power {}", i);
+    <Move> [case Left] => std::string("Move Left");
 
     // ERROR: No coverage for '<Move> [Right]' value.
   };
@@ -252,9 +252,9 @@ std::string cmdToStringV1(Command cmd) {
 ```c++
 std::string cmdToStringV2(Command cmd) {
   return inspect(cmd) { // OK
-    <FireBlasters> [i]  => std::format("Fire Blasters with power {}", i),
-    <Move> [case Left]  => std::string("Move Left"),
-    <Move> [case Right] => std::string("Move Right"),
+    <FireBlasters> [i]  => std::format("Fire Blasters with power {}", i);
+    <Move> [case Left]  => std::string("Move Left");
+    <Move> [case Right] => std::string("Move Right");
   };
 }
 ```
@@ -269,10 +269,10 @@ auto s = cmdToStringV2(pathological); // throws 'std::bad_variant_access'
 ```c++
 std::string cmdToStringV3(Command cmd) {
   return inspect(cmd) {
-    <FireBlasters> [i]  => std::format("Fire Blasters with power {}", i),
-    <Move> [case Left]  => std::string("Move Left"),
-    <Move> [case Right] => std::string("Move Right"),
-    __ => std::string("Pathological Command"),
+    <FireBlasters> [i]  => std::format("Fire Blasters with power {}", i);
+    <Move> [case Left]  => std::string("Move Left");
+    <Move> [case Right] => std::string("Move Right");
+    __ => std::string("Pathological Command");
   };
 }
 
@@ -303,9 +303,9 @@ struct MoveV2 : CommandV2 {
 ```c++
 std::string cmdToStringV5(CommandV2 cmd) {
   return inspect(cmd) {
-    <FireBlasters> [i]  => std::format("Fire Blasters with power {}", i),
-    <Move> [case Left]  => std::string("Move Left"),
-    <Move> [case Right] => std::string("Move Right"),
+    <FireBlasters> [i]  => std::format("Fire Blasters with power {}", i);
+    <Move> [case Left]  => std::string("Move Left");
+    <Move> [case Right] => std::string("Move Right");
 
     // ERROR, exhaustive pattern required
   };
@@ -315,10 +315,10 @@ std::string cmdToStringV5(CommandV2 cmd) {
 ```c++
 std::string cmdToStringV5(CommandV2 cmd) {
   return inspect(cmd) { // OK
-    <FireBlasters> [i]  => std::format("Fire Blasters with power {}", i),
-    <Move> [case Left]  => std::string("Move Left"),
-    <Move> [case Right] => std::string("Move Right"),
-    __                  => std::string("Unknown"),
+    <FireBlasters> [i]  => std::format("Fire Blasters with power {}", i);
+    <Move> [case Left]  => std::string("Move Left");
+    <Move> [case Right] => std::string("Move Right");
+    __                  => std::string("Unknown");
   };
 }
 ```
@@ -328,10 +328,10 @@ std::string cmdToStringV5(CommandV2 cmd) {
 ```c++
 int fib(int n) {
   return inspect(n) {          // ERROR: Patterns not exhaustive
-    0             => 0,
-    1             => 1,
-    n if (n >= 1) => fib(n-1) + fib(n-2),
-    n if (n < 0)  => throw std::invalid_argument("fib called with negative"),
+    0             => 0;
+    1             => 1;
+    n if (n >= 1) => fib(n-1) + fib(n-2);
+    n if (n < 0)  => !{ throw std::invalid_argument("fib called with negative") };
   };
 }
 ```
@@ -339,10 +339,10 @@ int fib(int n) {
 ```c++
 int fib(int n) {
   return inspect(n) {          // OK
-    0             => 0,
-    1             => 1,
-    n if (n >= 1) => fib(n-1) + fib(n-2),
-    __            => throw std::invalid_argument("fib called with negative"),
+    0             => 0;
+    1             => 1;
+    n if (n >= 1) => fib(n-1) + fib(n-2);
+    __            => !{ throw std::invalid_argument("fib called with negative") };
   };
 }
 ```
@@ -364,11 +364,11 @@ struct BinaryTree : std::variant<Node, Branch> {
 ```c++
 bool depthTwo(const BinaryTree & t) {
   return inspect(t) {             // ERROR: Patterns not exhaustive
-    <Node> __                                 => false,
-    <Branch> [(*?) <Branch> __, __]           => true,
-    <Branch> [__, (*?) <Branch> __]           => true,
-    <Branch> [(*?) <Node> __, (*?) <Node> __] => false,
-    <Branch> [nullptr, nullptr]               => false,
+    <Node> __                                 => false;
+    <Branch> [(*?) <Branch> __, __]           => true;
+    <Branch> [__, (*?) <Branch> __]           => true;
+    <Branch> [(*?) <Node> __, (*?) <Node> __] => false;
+    <Branch> [nullptr, nullptr]               => false;
   };
 }
 ```
@@ -376,11 +376,11 @@ bool depthTwo(const BinaryTree & t) {
 ```c++
 bool depthTwo(const BinaryTree & t) {
   return inspect(t) {             // OK
-    <Node> __ => false,
-    <Branch> [(*?) <Branch> __, __]           => true,
-    <Branch> [__, (*?) <Branch> __]           => true,
-    <Branch> [(*?) <Node> __, (*?) <Node> __] => false,
-    <Branch> __                               => false,
+    <Node> __ => false;
+    <Branch> [(*?) <Branch> __, __]           => true;
+    <Branch> [__, (*?) <Branch> __]           => true;
+    <Branch> [(*?) <Node> __, (*?) <Node> __] => false;
+    <Branch> __                               => false;
   };
 }
 ```
@@ -390,10 +390,10 @@ Note the missing `nullptr` handling in the following example.
 ```c++
 bool depthTwo(const BinaryTree & t) {
   return inspect(t) {             // OK
-    <Node> __ => false,
-    <Branch> [(*!) <Branch> __, __]           => true,
-    <Branch> [__, (*!) <Branch> __]           => true,
-    <Branch> [(*!) <Node> __, (*!) <Node> __] => false,
+    <Node> __ => false;
+    <Branch> [(*!) <Branch> __, __]           => true;
+    <Branch> [__, (*!) <Branch> __]           => true;
+    <Branch> [(*!) <Node> __, (*!) <Node> __] => false;
   };
 }
 ```
@@ -403,9 +403,9 @@ Our Preferred implementation
 ```c++
 bool depthTwo(const BinaryTree & t) {
   return inspect(t) {
-    <Node>   __                               => false,
-    <Branch> [(*!) <Node> __, (*!) <Node> __] => false,
-    __                                        => true,
+    <Node>   __                               => false;
+    <Branch> [(*!) <Node> __, (*!) <Node> __] => false;
+    __                                        => true;
   };
 }
 ```
@@ -414,15 +414,15 @@ bool depthTwo(const BinaryTree & t) {
 
 ```c++
 int val = inspect(str) {     //ERROR: Non-exhaustive
-  (regex_pat<"(\\d+)"> ?) [digits] => std::atoi(digits),
-  (regex_pat<".*"> ?)     __       => -1,
+  (regex_pat<"(\\d+)"> ?) [digits] => std::atoi(digits);
+  (regex_pat<".*"> ?)     __       => -1;
 }
 ```
 
 ```c++
 int val = inspect(str) {     //OK
-  (regex_pat<"(\\d+)"> ?) [digits] => std::atoi(digits),
-  __                               => -1,
+  (regex_pat<"(\\d+)"> ?) [digits] => std::atoi(digits);
+  __                               => -1;
 }
 ```
 


### PR DESCRIPTION
- Always use `;` as separator, instead of `,`.
- Use `!{ ... }` syntax for throw branches.