### PR TITLE
Update D2211R0 to use the P1371R3 syntax.

### DIFF
--- a/D2211R0.md
+++ b/D2211R0.md
@@ -81,7 +81,7 @@ type. The wildcard pattern (`__`) in the third arm of the `inspect` statement
 below is one such pattern, but the literal `2` in the second arm is not.
 
 ```C++
-inspect(i) {
+inspect(i) -> std::ostream& {
   1  => std::cout << "one";
   2  => std::cout << "two";
   __ => std::cout << "something else";
@@ -91,7 +91,7 @@ inspect(i) {
 Binding patterns, such as `x` in the following example, are also exhaustive.
 
 ```C++
-inspect(i) {
+inspect(i) -> std::ostream& {
   1 => std::cout << "one";
   2 => std::cout << "two";
   x => std::cout << x;
@@ -229,7 +229,7 @@ struct FlagsV1 {
 inspect(flagsV1) {
   [false, false] => /*...*/;
   [true , false] => /*...*/;
-  [_    , true ] => /*...*/;
+  [__   , true ] => /*...*/;
 };
 ```
 
@@ -252,7 +252,7 @@ constexpr auto allFalse = FlagsV2{ .firstFlag=false,
 inspect(flagsV2) {
   case allFalse => /*...*/;
   [true, false] => /*...*/;
-  [_   , true ] => /*...*/;
+  [__  , true ] => /*...*/;
 };
 ```
 
@@ -278,7 +278,7 @@ constexpr auto allFalse = FlagsV3{ .firstFlag=false,
 inspect(flagsV3) {
   case allFalse => /*...*/;
   [true, false] => /*...*/;
-  [_   , true ] => /*...*/;  // ERROR: {false, false} case not handled.
+  [__  , true ] => /*...*/;  // ERROR: {false, false} case not handled.
 };
 ```
 
@@ -732,10 +732,10 @@ int main() {
   Color c;
   std::cin >> c;
 
-  inspect(c) {
-    case RED   => std::cout << "(1,0,0)" << std::endl,
-    case GREEN => std::cout << "(0,1,0)" << std::endl,
-    __ => std::cerr << "Bad selection!" << std::endl,
+  inspect(c) -> std::ostream& {
+    case RED   => std::cout << "(1,0,0)" << std::endl;
+    case GREEN => std::cout << "(0,1,0)" << std::endl;
+    __ => std::cerr << "Bad selection!" << std::endl;
   };
 }
 ```
@@ -754,7 +754,7 @@ error as desired, indicating the missing `BLUE` case:
 ```c++
 // OPTION 1
 
-inspect(c) {
+inspect(c) -> std::ostream& {
   case RED   : std::cout << "(1,0,0)" << std::endl;
   case GREEN : std::cout << "(0,1,0)" << std::endl;
   __ if(true) : std::cerr << "Bad selection!" << std::endl;
@@ -768,7 +768,7 @@ be empty:
 ```c++
 // OPTION 2
 
-inspect(c) {
+inspect(c) -> std::ostream& {
   case RED   : std::cout << "(1,0,0)" << std::endl;
   case GREEN : std::cout << "(0,1,0)" << std::endl;
   __ if() : std::cerr << "Bad selection!" << std::endl;
@@ -781,7 +781,7 @@ annotation) to more directly indicate this is an exceptional case:
 ```c++
 // OPTION 3
 
-inspect(c) {
+inspect(c) -> std::ostream& {
   case RED   : std::cout << "(1,0,0)" << std::endl;
   case GREEN : std::cout << "(0,1,0)" << std::endl;
   __ exceptional : std::cerr << "Bad selection!" << std::endl;

--- a/D2211R0.md
+++ b/D2211R0.md
@@ -35,14 +35,14 @@ enum Color { Red, Green, Blue };
 //...
 Color c = /*...*/;
 vec3 v = inspect(c) {                 // ERROR: Missing case 'Blue'
-  case Red   => vec3(1.0, 0.0, 0.0),
-  case Green => vec3(0.0, 1.0, 0.0),
+  case Red   => vec3(1.0, 0.0, 0.0);
+  case Green => vec3(0.0, 1.0, 0.0);
 };
 
 vec3 v2 = inspect(c) {                // OKAY
-  case Red   => vec3(1.0, 0.0, 0.0),
-  case Green => vec3(0.0, 1.0, 0.0),
-  case Blue  => vec3(0.0, 0.0, 1.0),
+  case Red   => vec3(1.0, 0.0, 0.0);
+  case Green => vec3(0.0, 1.0, 0.0);
+  case Blue  => vec3(0.0, 0.0, 1.0);
 };
 ```
 
@@ -82,9 +82,9 @@ below is one such pattern, but the literal `2` in the second arm is not.
 
 ```C++
 inspect(i) {
-  1  => std::cout << "one",
-  2  => std::cout << "two",
-  __ => std::cout << "something else",
+  1  => std::cout << "one";
+  2  => std::cout << "two";
+  __ => std::cout << "something else";
 }
 ```
 
@@ -92,9 +92,9 @@ Binding patterns, such as `x` in the following example, are also exhaustive.
 
 ```C++
 inspect(i) {
-  1 => std::cout << "one",
-  2 => std::cout << "two",
-  x => std::cout << x,
+  1 => std::cout << "one";
+  2 => std::cout << "two";
+  x => std::cout << x;
 }
 ```
 
@@ -108,8 +108,8 @@ struct Point { int xCoordinate; int yCoordinate; }
 struct Box { Point topLeft; int width; int height };
 
 inspect(box) {
-  [tl, w, h] => /*...*/,
-  [[x,y], w, h] => /*...*/
+  [tl, w, h] => /*...*/;
+  [[x,y], w, h] => /*...*/;
 }
 ```
 
@@ -120,16 +120,16 @@ pattern that matches the value `false`.
 
 ```c++
 bool b = /*...*/;
-char const * const str = inspect(b) { true => "true" }; // ERROR: missing
-                                                        // false pattern
+char const * const str = inspect(b) { true => "true"; }; // ERROR: missing
+                                                         // false pattern
 ```
 
 This error can be fixed by adding an exhaustive pattern.
 
 ```c++
 char const * const str = inspect(b) {
-  true => "true",
-  __   => "false"                     // OKAY, pattern exhaustive
+  true => "true";
+  __   => "false";                    // OKAY, pattern exhaustive
 };
 ```
 
@@ -140,8 +140,8 @@ fix the error.
 ```c++
 bool b = /*...*/;
 char const * const str = inspect(b) {
-  true => "true",
-  false => "false"                    // OKAY, all values are covered.
+  true => "true";
+  false => "false";                   // OKAY, all values are covered.
 };
 ```
 
@@ -159,8 +159,8 @@ enum Color { Red, Green, Blue };
 //...
 Color c = /*...*/;
 vec3 v = inspect(c) {                 // ERROR: Missing case 'Blue'
-  case Red   => vec3(1.0, 0.0, 0.0),
-  case Green => vec3(0.0, 1.0, 0.0),
+  case Red   => vec3(1.0, 0.0, 0.0);
+  case Green => vec3(0.0, 1.0, 0.0);
 };
 ```
 
@@ -168,9 +168,9 @@ This can be fixed by adding a pattern for the missing `Blue` enumerator.
 
 ```C++
 vec3 v = inspect(c) {                // OKAY
-  case Red   => vec3(1.0, 0.0, 0.0),
-  case Green => vec3(0.0, 1.0, 0.0),
-  case Blue  => vec3(0.0, 0.0, 1.0),
+  case Red   => vec3(1.0, 0.0, 0.0);
+  case Green => vec3(0.0, 1.0, 0.0);
+  case Blue  => vec3(0.0, 0.0, 1.0);
 };
 ```
 
@@ -190,9 +190,9 @@ a call to `std::terminate` seems the most palatable.
 Color val_outside_enumerators = static_cast<Color>(3);
 
 vec3 v = inspect(val_outside_enumerators) {     // 'std::terminate' at runtime
-  case Red   => vec3(1.0, 0.0, 0.0),
-  case Green => vec3(0.0, 1.0, 0.0),
-  case Blue  => vec3(0.0, 0.0, 1.0),
+  case Red   => vec3(1.0, 0.0, 0.0);
+  case Green => vec3(0.0, 1.0, 0.0);
+  case Blue  => vec3(0.0, 0.0, 1.0);
 };
 ```
 
@@ -205,10 +205,10 @@ behavior is desired.
 Color val_outside_enumerators = static_cast<Color>(3);
 
 vec3 v = inspect(val_outside_enumerators) {     // Throw exception at runtime
-  case Red   => vec3(1.0, 0.0, 0.0),
-  case Green => vec3(0.0, 1.0, 0.0),
-  case Blue  => vec3(0.0, 0.0, 1.0),
-  __         => throw Up{},
+  case Red   => vec3(1.0, 0.0, 0.0);
+  case Green => vec3(0.0, 1.0, 0.0);
+  case Blue  => vec3(0.0, 0.0, 1.0);
+  __         => throw Up{};
 };
 ```
 
@@ -227,9 +227,9 @@ struct FlagsV1 {
 
 ```C++
 inspect(flagsV1) {
-  [false, false] => /*...*/,
-  [true , false] => /*...*/,
-  [_    , true ] => /*...*/,
+  [false, false] => /*...*/;
+  [true , false] => /*...*/;
+  [_    , true ] => /*...*/;
 };
 ```
 
@@ -250,9 +250,9 @@ struct FlagsV2 {
 constexpr auto allFalse = FlagsV2{ .firstFlag=false,
                                    .secondFlag=false };
 inspect(flagsV2) {
-  case allFalse => /*...*/,
-  [true, false] => /*...*/,
-  [_   , true ] => /*...*/,
+  case allFalse => /*...*/;
+  [true, false] => /*...*/;
+  [_   , true ] => /*...*/;
 };
 ```
 
@@ -276,9 +276,9 @@ struct FlagsV3 {
 constexpr auto allFalse = FlagsV3{ .firstFlag=false,
                                    .secondFlag=false };
 inspect(flagsV3) {
-  case allFalse => /*...*/,
-  [true, false] => /*...*/,
-  [_   , true ] => /*...*/,  // ERROR: {false, false} case not handled.
+  case allFalse => /*...*/;
+  [true, false] => /*...*/;
+  [_   , true ] => /*...*/;  // ERROR: {false, false} case not handled.
 };
 ```
 
@@ -318,8 +318,8 @@ expressions arms. This is detected and will produce an error at compile time.
 ```c++
 std::string cmdToStringV1(Command cmd) {
   return inspect(cmd) {
-    <FireBlasters> [i] => std::format("Fire Blasters with power {}", i),
-    <Move> [case Left] => std::string("Move Left"),
+    <FireBlasters> [i] => std::format("Fire Blasters with power {}", i);
+    <Move> [case Left] => std::string("Move Left");
 
     // ERROR: No coverage for '<Move> [Right]' value.
   };
@@ -331,9 +331,9 @@ Adding a "move right" case fixes the issue.
 ```c++
 std::string cmdToStringV2(Command cmd) {
   return inspect(cmd) { // OK
-    <FireBlasters> [i]  => std::format("Fire Blasters with power {}", i),
-    <Move> [case Left]  => std::string("Move Left"),
-    <Move> [case Right] => std::string("Move Right"),
+    <FireBlasters> [i]  => std::format("Fire Blasters with power {}", i);
+    <Move> [case Left]  => std::string("Move Left");
+    <Move> [case Right] => std::string("Move Right");
   };
 }
 ```
@@ -355,10 +355,10 @@ If there is desire to handle this case explicitly, one may use a wildcard.
 ```c++
 std::string cmdToStringV3(Command cmd) {
   return inspect(cmd) {
-    <FireBlasters> [i]  => std::format("Fire Blasters with power {}", i),
-    <Move> [case Left]  => std::string("Move Left"),
-    <Move> [case Right] => std::string("Move Right"),
-    __ => std::string("Pathological Command"),
+    <FireBlasters> [i]  => std::format("Fire Blasters with power {}", i);
+    <Move> [case Left]  => std::string("Move Left");
+    <Move> [case Right] => std::string("Move Right");
+    __ => std::string("Pathological Command");
   };
 }
 
@@ -398,9 +398,9 @@ values will not satisfy the exhaustiveness checker.
 ```c++
 std::string cmdToStringV5(CommandV2 cmd) {
   return inspect(cmd) {
-    <FireBlastersV2> [i]  => std::format("Fire Blasters with power {}", i),
-    <MoveV2> [case Left]  => std::string("Move Left"),
-    <MoveV2> [case Right] => std::string("Move Right"),
+    <FireBlastersV2> [i]  => std::format("Fire Blasters with power {}", i);
+    <MoveV2> [case Left]  => std::string("Move Left");
+    <MoveV2> [case Right] => std::string("Move Right");
 
     // ERROR, exhaustive pattern required
   };
@@ -412,10 +412,10 @@ Instead, an exhaustive pattern is required when doing this kind of downcasting.
 ```c++
 std::string cmdToStringV5(CommandV2 cmd) {
   return inspect(cmd) { // OK
-    <FireBlastersV2> [i]  => std::format("Fire Blasters with power {}", i),
-    <MoveV2> [case Left]  => std::string("Move Left"),
-    <MoveV2> [case Right] => std::string("Move Right"),
-    __                    => std::string("Unknown"),
+    <FireBlastersV2> [i]  => std::format("Fire Blasters with power {}", i);
+    <MoveV2> [case Left]  => std::string("Move Left");
+    <MoveV2> [case Right] => std::string("Move Right");
+    __                    => std::string("Unknown");
   };
 }
 ```
@@ -430,10 +430,10 @@ determination.
 ```c++
 int fib(int n) {
   return inspect(n) {          // ERROR: Patterns not exhaustive
-    0             => 0,
-    1             => 1,
-    n if (n >= 1) => fib(n-1) + fib(n-2),
-    n if (n < 0)  => throw std::invalid_argument("fib called with negative"),
+    0             => 0;
+    1             => 1;
+    n if (n >= 1) => fib(n-1) + fib(n-2);
+    n if (n < 0)  => throw std::invalid_argument("fib called with negative");
   };
 }
 ```
@@ -444,10 +444,10 @@ exhaustive patterns as below.
 ```c++
 int fib(int n) {
   return inspect(n) {          // OK
-    0             => 0,
-    1             => 1,
-    n if (n >= 1) => fib(n-1) + fib(n-2),
-    __            => throw std::invalid_argument("fib called with negative"),
+    0             => 0;
+    1             => 1;
+    n if (n >= 1) => fib(n-1) + fib(n-2);
+    __            => throw std::invalid_argument("fib called with negative");
   };
 }
 ```
@@ -477,11 +477,11 @@ exhaustiveness.
 ```c++
 bool depthAtLeastTwo(const BinaryTree & t) {
   return inspect(t) {             // ERROR: Patterns not exhaustive
-    <Node> __                                 => false,
-    <Branch> [(*?) <Branch> __, __]           => true,
-    <Branch> [__, (*?) <Branch> __]           => true,
-    <Branch> [(*?) <Node> __, (*?) <Node> __] => false,
-    <Branch> [nullptr, nullptr]               => false,
+    <Node> __                                 => false;
+    <Branch> [(*?) <Branch> __, __]           => true;
+    <Branch> [__, (*?) <Branch> __]           => true;
+    <Branch> [(*?) <Node> __, (*?) <Node> __] => false;
+    <Branch> [nullptr, nullptr]               => false;
   };
 }
 ```
@@ -492,11 +492,11 @@ This can be fixed by replacing the `<Branch> [nullptr, nullptr]` pattern with
 ```c++
 bool depthAtLeastTwo(const BinaryTree & t) {
   return inspect(t) {             // OK
-    <Node> __ => false,
-    <Branch> [(*?) <Branch> __, __]           => true,
-    <Branch> [__, (*?) <Branch> __]           => true,
-    <Branch> [(*?) <Node> __, (*?) <Node> __] => false,
-    <Branch> __                               => false,
+    <Node> __ => false;
+    <Branch> [(*?) <Branch> __, __]           => true;
+    <Branch> [__, (*?) <Branch> __]           => true;
+    <Branch> [(*?) <Node> __, (*?) <Node> __] => false;
+    <Branch> __                               => false;
   };
 }
 ```
@@ -510,10 +510,10 @@ is not valid input.
 ```c++
 bool depthAtLeastTwo(const BinaryTree & t) {
   return inspect(t) {             // OK
-    <Node> __ => false,
-    <Branch> [(*!) <Branch> __, __]           => true,
-    <Branch> [__, (*!) <Branch> __]           => true,
-    <Branch> [(*!) <Node> __, (*!) <Node> __] => false,
+    <Node> __ => false;
+    <Branch> [(*!) <Branch> __, __]           => true;
+    <Branch> [__, (*!) <Branch> __]           => true;
+    <Branch> [(*!) <Node> __, (*!) <Node> __] => false;
   };
 }
 ```
@@ -524,9 +524,9 @@ For reference, we provide our preferred implementation below.
 bool depthAtLeastTwo(const BinaryTree & t) {
   assert(no_nulls(t));
   return inspect(t) {
-    <Node>   __                               => false,
-    <Branch> [(*!) <Node> __, (*!) <Node> __] => false,
-    __                                        => true,
+    <Node>   __                               => false;
+    <Branch> [(*!) <Node> __, (*!) <Node> __] => false;
+    __                                        => true;
   };
 }
 ```
@@ -538,8 +538,8 @@ contribute to pattern matching exhaustiveness checking.
 
 ```c++
 int val = inspect(str) {     //ERROR: Non-exhaustive
-  (regex_pat<"(\\d+)"> ?) [digits] => std::atoi(digits),
-  (regex_pat<".*"> ?)     __       => -1,
+  (regex_pat<"(\\d+)"> ?) [digits] => std::atoi(digits);
+  (regex_pat<".*"> ?)     __       => -1;
 }
 ```
 
@@ -547,8 +547,8 @@ Exhaustive patterns need to be used in conjunction with these patterns.
 
 ```c++
 int val = inspect(str) {     //OK
-  (regex_pat<"(\\d+)"> ?) [digits] => std::atoi(digits),
-  __                               => -1,
+  (regex_pat<"(\\d+)"> ?) [digits] => std::atoi(digits);
+  __                               => -1;
 }
 ```
 
@@ -722,9 +722,9 @@ int main() {
   // Assuming an 'enumerators' reflection facility
   std::for_each(enumerators<Color>(), [](Color c) {
     std::cout << int(c) << " = "
-      << inspect(c){ case RED   => "Red",
-                     case GREEN => "Green",
-                     case BLUE  => "Blue",
+      << inspect(c){ case RED   => "Red";
+                     case GREEN => "Green";
+                     case BLUE  => "Blue";
                    }
       << std::endl;
   });


### PR DESCRIPTION
Changed commas to semicolons in inspect expressions and used ` -> std::ostream&` for `<iostream>` examples.