### PR TITLE
D1371R4: Add "Equality vs Identity" design decision

### DIFF
--- a/D1371R4.md
+++ b/D1371R4.md
@@ -25,6 +25,7 @@ toc-depth: 4
 # Revision History
   - R4
     - Use of `break` inside `inspect` expression.
+    - Add [Equality vs Identity when matching constant expressions]
   - R3
     - Updated [Design Overview] and other sections: `inspect` is always an expression.
     - Clarified that extractor pattern samples are not proposed for standardisation.
@@ -1361,6 +1362,46 @@ Both use cases are interesting and valid for `inspect`, but resulting `break` be
 
 Since `inspect` is a new construct and it doesn't have fall-through behaviour that `switch` had, we decided
 that it is more valuable to let `break` to denote iteration stop for enclosing loop.
+
+## Equality vs Identity when matching constant expressions
+
+When evaluating [Expression Pattern] we default to using `operator==` for comparison, rather than checking for bitwise identity.
+
+Imagine following code:
+
+```
+double foo() { return -0.0; }
+
+inspect (foo()) {
+  0.0 => /* ... */;
+  __ => throw Up{};
+}
+```
+
+It will be very surprising for user if the code above won't match `-0.0` to `0.0` and result in exception thrown.
+The intuitive solution is to follow the `operator==` logic and check that the values of the operands are equal.
+
+As a consequence of this decision, users won't be able to simply handle entities that have same value but different representation:
+
+```
+inspect (foo()) {
+  0.0 => /* ... */;
+  -0.0 => /* ... */; // Will never be matched, as 0.0 matches same value.
+  __ => throw Up{};
+}
+```
+
+And would have to use some means to disambiguate those values, by either using `bit_cast` or specialized matcher.
+
+Also note, that similar discussion was held for Non-Type Template Parameters. There the solution was to not use `operator==`, and rely on special set of rules. It was caused by multiple problems caused by "value equality":
+- Requirement for compilers to somehow normalize the value, so that mangling can be done in a portable way.
+- Some templates need to be specialized for different representations of the same value (i.e. `0.0` and `-0.0`)
+- Doesn't allow to specialize a template for `NaN`.
+
+The problems encountered for templates do not apply to the pattern matching the same way:
+- Pattern matching does not affect symbol mangling.
+- The difference between positive and negative zero can be evaluated inside the handler code.
+- `NaN` can be handled by either wildcard pattern or specialized matcher.
 
 # Runtime Performance
 

--- a/D1371R4.md
+++ b/D1371R4.md
@@ -1378,10 +1378,10 @@ inspect (foo()) {
 }
 ```
 
-It will be very surprising for user if the code above won't match `-0.0` to `0.0` and result in exception thrown.
+It will be very surprising for users if the code above won't match `-0.0` to `0.0` and results in a thrown exception.
 The intuitive solution is to follow the `operator==` logic and check that the values of the operands are equal.
 
-As a consequence of this decision, users won't be able to simply handle entities that have same value but different representation:
+As a consequence of this decision, users won't be able to simply handle entities that have same value but different representation as in the following snippet.
 
 ```
 inspect (foo()) {
@@ -1391,17 +1391,17 @@ inspect (foo()) {
 }
 ```
 
-And would have to use some means to disambiguate those values, by either using `bit_cast` or specialized matcher.
+In this situation, users would have to use some other means to disambiguate those values e.g. by either using `bit_cast` or a specialized matcher.
 
-Also note, that similar discussion was held for Non-Type Template Parameters. There the solution was to not use `operator==`, and rely on special set of rules. It was caused by multiple problems caused by "value equality":
-- Requirement for compilers to somehow normalize the value, so that mangling can be done in a portable way.
-- Some templates need to be specialized for different representations of the same value (i.e. `0.0` and `-0.0`)
-- Doesn't allow to specialize a template for `NaN`.
+Also note that a similar discussion was held for Non-Type Template Parameters, but there the solution was to rely on special set of rules instead of using `operator==`. This decision was motivated by multiple issues caused by "value equality":
+- Compilers would be required to somehow normalize the value so that mangling can be done portably.
+- Some templates need to be specialized for different representations of the same value (i.e. `0.0` and `-0.0`).
+- Value equality disallows a template specialization for `NaN`.
 
 The problems encountered for templates do not apply to the pattern matching the same way:
-- Pattern matching does not affect symbol mangling.
-- The difference between positive and negative zero can be evaluated inside the handler code.
-- `NaN` can be handled by either wildcard pattern or specialized matcher.
+- Pattern matching does not impact symbol mangling.
+- The difference between positive and negative zero can be observed inside the handler code.
+- `NaN` can be handled by either wildcard patterns or specialized matchers.
 
 # Runtime Performance
 


### PR DESCRIPTION
Described why we choose to follow the logic of `operator==` instead of bitwise equality.