### PR TITLE
Add clarification note about jump statements

### DIFF
--- a/D1371R4.md
+++ b/D1371R4.md
@@ -413,7 +413,9 @@ yield a value and should stop the execution either by returning from the enclosi
 throwing an exception or terminating the program. This allows users to express desired
 no-match behaviour or to act upon broken invariant, without affecting return type of the
 whole of `inspect` expression. If execution reaches end of the compound statement
-`std::terminate` is called.
+`std::terminate` is called. Patterns can also pass control directly to jump statements
+with no effect on type deduction for the inspect expression. No enclosing compound
+statement is necessary in this situation.
 
 When `inspect` is executed, its condition is evaluated and matched
 in order (first match semantics) against each pattern. If a pattern successfully


### PR DESCRIPTION
Made the option to use "bare" jump statements (without an enclosing compound statement) explicit.