### PR TITLE
Improve readability on phones

### DIFF
--- a/data/templates/14882.css
+++ b/data/templates/14882.css
@@ -7,6 +7,13 @@ body {
 		   from surrounding text by virtue of being sans serif. */
 	hyphens: auto;
 	line-height: 1.35;
+	text-align: justify;
+}
+
+@media screen and (max-width: 30em) {
+	body {
+		margin: 1.5em;
+	}
 }
 
 div.wrapper {


### PR DESCRIPTION
Closes #84.

If you'd like to know more about `@media` queries, https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout/Media_queries is a good resource.

I don't know why there is a `margin: 5em` in the `body` block right now, so I decided to leave it alone except on narrow devices. If you don't think it is actually needed, this can be simplified by just setting the margin to `1.5em` there and removing the whole `@media` block. I'd be happy to do whichever you prefer.