### PR TITLE
Point to requirements section in integration section

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ make <paper>.html # `<paper>.md` -> `generated/<paper>.html`
 
 ## Integration
 
+Install the necessary [requirements](#requirements) for your platform, then:
+
 ```bash
 git submodule add https://github.com/mpark/wg21.git
 


### PR DESCRIPTION
When setting this up for the first time, I missed the `# Requirements` section and got a cryptic error:

```
pandoc paper.md -o generated/paper.pdf -d wg21/data/defaults.yaml --bibliography wg21/data/csl.json
pandoc: xelatex: createProcess: posix_spawnp: illegal operation (Inappropriate ioctl for device)
make: *** [generated/paper.pdf] Error 1
```

You can determine the cause [with a quick google](https://github.com/jgm/pandoc/issues/7570#issuecomment-958748552), but I figured it might help folks in the future to get a nudge to install the dependencies before trying to generate their first document. 