### PR TITLE
Add mathjax support to pandoc command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ override DATADIR := $(ROOTDIR)data
 
 override define PANDOC
 $(eval override FILE := $(filter %.md, $^))
-$(eval override CMD := pandoc $(FILE) -o $@ -d $(DATADIR)/defaults.yaml)
+$(eval override CMD := pandoc $(FILE) -o $@ --mathjax -d $(DATADIR)/defaults.yaml)
 $(eval $(and $(DEFAULTS), override CMD += -d $(DEFAULTS)))
 $(eval $(and $(METADATA), override CMD += --metadata-file $(METADATA)))
 $(if $(filter %.html, $@),


### PR DESCRIPTION
Without this, math renders poorly (see left column).

![Screenshot from 2023-10-14 12-14-19](https://github.com/mpark/wg21/assets/1819744/b4bb673e-4ccc-424f-98b8-430309c7a282)

With this, it's at least acceptable.

![Screenshot from 2023-10-14 13-47-25](https://github.com/mpark/wg21/assets/1819744/d5b4bba2-88b5-44af-8269-ce4a6d67d4c2)