### PR TITLE
Implement stable name without a number

### DIFF
--- a/data/filters/wg21.py
+++ b/data/filters/wg21.py
@@ -349,26 +349,17 @@ def divspan(elem, doc):
     if 'pnum' in elem.classes and isinstance(elem, pf.Span):
         return pnum()
 
-    def process_sref(with_number):
+    if 'sref' in elem.classes and isinstance(elem, pf.Span):
         target = pf.stringify(elem)
         number = stable_names.get(target)
         link = pf.Link(
             pf.Str(f'[{target}]'),
             url=f'https://wg21.link/{target}')
         if number is not None:
-            if with_number:
-                return pf.Span(pf.Str(number), pf.Space(), link)
-            else:
-                return pf.Span(link)
+            return pf.Span(link) if 'unnumbered' in elem.classes else pf.Span(pf.Str(number), pf.Space(), link)
         else:
             pf.debug('mpark/wg21: stable name', target, 'not found')
             return link
-
-    if 'sref' in elem.classes and isinstance(elem, pf.Span):
-        return process_sref(True)
-
-    if 'srefnn' in elem.classes and isinstance(elem, pf.Span):
-        return process_sref(False)
 
     note_cls = next(iter(cls for cls in elem.classes if cls in {'example', 'note', 'ednote'}), None)
     if note_cls == 'example':  example()

--- a/data/filters/wg21.py
+++ b/data/filters/wg21.py
@@ -349,17 +349,26 @@ def divspan(elem, doc):
     if 'pnum' in elem.classes and isinstance(elem, pf.Span):
         return pnum()
 
-    if 'sref' in elem.classes and isinstance(elem, pf.Span):
+    def process_sref(with_number):
         target = pf.stringify(elem)
         number = stable_names.get(target)
         link = pf.Link(
             pf.Str(f'[{target}]'),
             url=f'https://wg21.link/{target}')
         if number is not None:
-            return pf.Span(pf.Str(number), pf.Space(), link)
+            if with_number:
+                return pf.Span(pf.Str(number), pf.Space(), link)
+            else:
+                return pf.Span(link)
         else:
             pf.debug('mpark/wg21: stable name', target, 'not found')
             return link
+
+    if 'sref' in elem.classes and isinstance(elem, pf.Span):
+        return process_sref(True)
+
+    if 'srefnn' in elem.classes and isinstance(elem, pf.Span):
+        return process_sref(False)
 
     note_cls = next(iter(cls for cls in elem.classes if cls in {'example', 'note', 'ednote'}), None)
     if note_cls == 'example':  example()


### PR DESCRIPTION
## Motivation

Sometimes one wants to use a stable link from the standard but doesn't want a number to be automatically inserted. That was a perfectly reasonable choice for [P3490R0](https:://wg21.link/P3490) where we have a link to [[algorithms]](https://eel.is/c++draft/algorithms) in introduction. It doesn't look nice in this very place and also doesn't bring any useful information.

While it can be overcome by using just Markdown references having such a shortcut is a good feature in my opinion.

## API

I propose `{.srefnn}` as a name (`nn` means "no number")

## Further work

If a proposal looks reasonable I am ready to add a documentation
