### PR TITLE
Upstreaming functionality from Tim

### DIFF
--- a/data/filters/wg21.py
+++ b/data/filters/wg21.py
@@ -295,11 +295,11 @@ def divspan(elem, doc):
             pf.RawInline('}', 'latex'))
         elem.attributes['style'] = f'color: #{html_color}'
 
-    def _nonnormative(name):
+    def _nonnormative(name, number='?'):
         wrap_elem(
-            pf.Span(pf.Str('[ '), pf.Emph(pf.Str(f'{name.title()}:')), pf.Space),
+            pf.Span(pf.Str('[\xa0'), pf.Emph(pf.Str(f'{name.title()} {number}:')), pf.Space),
             elem,
-            pf.Span(pf.Str(' — '), pf.Emph(pf.Str(f'end {name.lower()}')), pf.Str(' ]')))
+            pf.Span(pf.Str(' —\xa0'), pf.Emph(pf.Str(f'end {name.lower()}')), pf.Str('\xa0]')))
 
     def _diff(color, latex_tag, html_tag):
         if isinstance(elem, pf.Span):
@@ -334,8 +334,8 @@ def divspan(elem, doc):
 
         return pf.Superscript(pf.Str(num))
 
-    def example(): _nonnormative('example')
-    def note():    _nonnormative('note')
+    def example(number='?'): _nonnormative('example', number)
+    def note(number='?'):    _nonnormative('note', number)
     def ednote():
         wrap_elem(pf.Str("[ Editor's note: "), elem, pf.Str(' ]'))
         _color('0000ff')
@@ -366,11 +366,11 @@ def divspan(elem, doc):
             pf.debug('mpark/wg21: stable name', target, 'not found')
             return link
 
-    note_cls = next(iter(cls for cls in elem.classes if cls in {'example', 'note', 'ednote', 'draftnote'}), None)
-    if note_cls == 'example':  example()
-    elif note_cls == 'note':   note()
-    elif note_cls == 'ednote': ednote(); return
-    elif note_cls == 'draftnote': draftnote(); return
+    for cls in elem.classes:
+        if cls.startswith('note'):      note(cls[4:] or '?')
+        elif cls.startswith('example'): example(cls[7:] or '?')
+        elif note_cls == 'ednote':      ednote(); return
+        elif note_cls == 'draftnote':   draftnote(); return
 
     diff_cls = next(iter(cls for cls in elem.classes if cls in {'add', 'rm'}), None)
     if diff_cls == 'add':  add()

--- a/data/filters/wg21.py
+++ b/data/filters/wg21.py
@@ -39,7 +39,7 @@ def prepare(doc):
     doc.metadata['pagetitle'] = pf.convert_text(
         pf.Plain(*doc.metadata['title'].content),
         input_format='panflute',
-        output_format='markdown')
+        output_format='plain')
 
     datadir = doc.get_metadata('datadir')
 

--- a/data/filters/wg21.py
+++ b/data/filters/wg21.py
@@ -44,7 +44,7 @@ def prepare(doc):
     datadir = doc.get_metadata('datadir')
 
     with open(os.path.join(datadir, 'annex-f'), 'r') as f:
-        stable_names.update(line.split(maxsplit=1) for line in f)
+        stable_names.update(line.rstrip().split(maxsplit=1) for line in f)
 
     def highlighting(output_format):
         return pf.convert_text(

--- a/data/filters/wg21.py
+++ b/data/filters/wg21.py
@@ -18,6 +18,7 @@ stable_names = {}
 current_pnum = {}
 current_note = 0
 current_example = 0
+current_pnum_count = 0
 
 refs = {}
 
@@ -372,11 +373,15 @@ def divspan(elem, doc):
         if '.' in num:
             num = f'({num})'
 
+        global current_pnum_count
+        current_pnum_count = current_pnum_count + 1
+
         if doc.format == 'latex':
             return pf.RawInline(f'\\pnum{{{num}}}', 'latex')
         elif doc.format == 'html':
             return pf.Span(
-                pf.RawInline(f'<a class="marginalized">{num}</a>', 'html'),
+                pf.RawInline(f'<a class="marginalized" href="#pnum_{current_pnum_count}"'
+                f' id="pnum_{current_pnum_count}">{num}</a>', 'html'),
                 classes=['marginalizedparent'])
 
         return pf.Superscript(pf.Str(num))

--- a/data/filters/wg21.py
+++ b/data/filters/wg21.py
@@ -452,10 +452,10 @@ def divspan(elem, doc):
                 current_example = current_example + 1
                 num = str(current_example)
             example(num)
-        elif note_cls == 'ednote':
+        elif cls == 'ednote':
             ednote()
             return
-        elif note_cls == 'draftnote':
+        elif cls == 'draftnote':
             draftnote()
             return
 


### PR DESCRIPTION
A block of commits that @timsong-cpp added to my fork a while back that I've found quite useful:

* (auto-)numbered notes and examples
* auto-numbering `pnum` (so that you can write `#.#` instead of `1.1` then `1.2` then `1.3` then ...)
* `pnum` links