### PR TITLE
Support $exposition-only-name$

### DIFF
--- a/data/filters/wg21.py
+++ b/data/filters/wg21.py
@@ -14,7 +14,7 @@ import panflute as pf
 import re
 
 embedded_md = re.compile('@@(.*?)@@|@(.*?)@')
-expos_name = re.compile('\$([\w\-\s]*?)\$')
+expos_name = re.compile(r'\$([\w\-\s]*?)\$')
 stable_names = {}
 refs = {}
 

--- a/data/syntax/isocpp.xml
+++ b/data/syntax/isocpp.xml
@@ -300,6 +300,8 @@
         <!-- Match embedded Markdown -->
         <RegExpr attribute="Ignore" context="#stay" String="@@.*?@@" />
         <RegExpr attribute="Ignore" context="#stay" String="@.*?@" />
+        <!-- Match exposition-only names -->
+        <RegExpr attribute="Ignore" context="#stay" String="\$[\w\-\s]*?\$" />
         <!-- Match keywords -->
         <IncludeRules context="match keywords" />
         <!-- Match string literals -->


### PR DESCRIPTION
`$expos-only-name$` is basically shorthand for `@*expos-only-name*@`, but it's so common in wording to need something like that.