### PR TITLE
Adding links to [Latest] and [Status]

### DIFF
--- a/data/filters/wg21.py
+++ b/data/filters/wg21.py
@@ -36,11 +36,12 @@ def prepare(doc):
     if date == 'today':
         doc.metadata['date'] = datetime.date.today().isoformat()
 
-    draft, document, revision = re.match("([PD])([0-9]+)R([0-9]+)", doc.get_metadata('document').upper()).groups()
-    doc.metadata['draft'] = draft == 'D'
-    doc.metadata['document'] = document
-    doc.metadata['revision'] = revision
-
+    document = doc.get_metadata('document')
+    number = re.match("[PD]([0-9]+)R[0-9]+", document.upper())
+    if number is not None:
+        doc.metadata['number'] = number.group(1)
+    else:
+        pf.debug('mpark/wg21: document ', document, 'is in an unrecognized format')
     doc.metadata['pagetitle'] = pf.convert_text(
         pf.Plain(*doc.metadata['title'].content),
         input_format='panflute',

--- a/data/filters/wg21.py
+++ b/data/filters/wg21.py
@@ -36,6 +36,11 @@ def prepare(doc):
     if date == 'today':
         doc.metadata['date'] = datetime.date.today().isoformat()
 
+    draft, document, revision = re.match("([PD])([0-9]+)R([0-9]+)", doc.get_metadata('document').upper()).groups()
+    doc.metadata['draft'] = draft == 'D'
+    doc.metadata['document'] = document
+    doc.metadata['revision'] = revision
+
     doc.metadata['pagetitle'] = pf.convert_text(
         pf.Plain(*doc.metadata['title'].content),
         input_format='panflute',

--- a/data/metadata.yaml
+++ b/data/metadata.yaml
@@ -22,6 +22,7 @@ citecolor: blue
 linkcolor: blue
 urlcolor: blue
 toccolor: black
+lang: en
 
 uccolor: '898887'
 addcolor: '006e28'

--- a/data/templates/wg21.html
+++ b/data/templates/wg21.html
@@ -65,8 +65,8 @@ $endif$
     <td>
       $document$
 $if(number)$
-      <a href="https://wg21.link/P$number$">[Latest]</a>
-      <a href="https://wg21.link/P$number$/status">[Status]</a>
+      [<a href="https://wg21.link/P$number$">Latest</a>]
+      [<a href="https://wg21.link/P$number$/status">Status</a>]
 $endif$
     </td>
   </tr>

--- a/data/templates/wg21.html
+++ b/data/templates/wg21.html
@@ -62,7 +62,13 @@ $endif$
 <table style="border:none;float:right">
   <tr>
     <td>Document #:</td>
-    <td>$if(draft)$D$else$P$endif$$document$R$revision$ <a href="https://wg21.link/P$document$">[Latest]</a> <a href="https://wg21.link/P$document$/status">[Status]</a></td>
+    <td>
+      $document$
+$if(number)$
+      <a href="https://wg21.link/P$number$">[Latest]</a>
+      <a href="https://wg21.link/P$number$/status">[Status]</a>
+$endif$
+    </td>
   </tr>
   <tr>
     <td>Date:</td>

--- a/data/templates/wg21.html
+++ b/data/templates/wg21.html
@@ -62,7 +62,7 @@ $endif$
 <table style="border:none;float:right">
   <tr>
     <td>Document #:</td>
-    <td>$document$</td>
+    <td>$if(draft)$D$else$P$endif$$document$R$revision$ <a href="https://wg21.link/P$document$">[Latest]</a> <a href="https://wg21.link/P$document$/status">[Status]</a></td>
   </tr>
   <tr>
     <td>Date:</td>


### PR DESCRIPTION
Two of the things you usually want to know when looking at a paper are:

1. What is the latest revision of this paper?
2. What is the current status of this paper?

Since we know what the paper is, it's easy to just add a link to `wg21.link/pNNNN` and `wg21.link/pNNNN/status`, which get you (1) and (2), respectively. 

> Document # P3525R0 [[Latest]](https://wg21.link/P3525) [[Status]](https://wg21.link/P3525/status)

This PR also adds `lang: en` to the metadata, which makes hyphenation actually work. 