### PR TITLE
Update Ubuntu installation instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ brew install mactex # Only for PDF papers
 ### Ubuntu
 
 ```bash
-sudo apt-get install texlive-latex-base # Only for PDF papers
+sudo apt-get install texlive-xetex # Only for PDF papers
 ```
 
 ### Debian


### PR DESCRIPTION
pandoc error "pandoc: xelatex not found." occurred on: WSL 24.04.1 LTS
Recommended fix: install instead:
```bash
sudo apt install texlive-xetex
```
This PR is for adding a note on the README.md file.