### PR TITLE
permit `{.sref}` links to individual paragraphs

### DIFF
--- a/data/filters/wg21.py
+++ b/data/filters/wg21.py
@@ -365,7 +365,7 @@ def divspan(elem, doc):
 
     if 'sref' in elem.classes and isinstance(elem, pf.Span):
         target = pf.stringify(elem)
-        number = stable_names.get(target)
+        number = stable_names.get(target.split('#')[0])
         link = pf.Link(
             pf.Str(f'[{target}]'),
             url=f'https://wg21.link/{target}')


### PR DESCRIPTION
currently an sref like `[exec.continues.on#5]{.sref}` correctly generates a link to p5 of `[exec.continues.on]`, but will generate a warning:

```
mpark/wg21: stable name exec.continues.on#5 not found
```

and then fail to include the subsection number. this PR fixes that.