### PR TITLE
Disable mobile browser text inflation algorithms using CSS

### DIFF
--- a/data/templates/14882.css
+++ b/data/templates/14882.css
@@ -8,6 +8,14 @@ body {
 	hyphens: auto;
 	line-height: 1.35;
 	text-align: justify;
+		/* Some browsers, particularly mobile Safari, implement text inflation
+		   algorithms intended to improve readability of text on small display
+		   sizes. This interacts badly with papers because it can lead to
+		   different font size settings being applied to each individual line of
+		   code. These properties disable the text inflation algorithm. */
+	-webkit-text-size-adjust: none;
+	-moz-text-size-adjust: none;
+	text-size-adjust: none;
 }
 
 @media screen and (max-width: 30em) {


### PR DESCRIPTION
Some browsers, particularly mobile Safari, implement text inflation algorithms intended to improve readability of text on small display sizes. This interacts badly with papers because it can lead to different font size settings being applied to each individual line of code. This commit adds CSS properties which disable the text inflation algorithm.

References:

Apple: https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariWebContent/AdjustingtheTextSize/AdjustingtheTextSize.html

MDN: https://developer.mozilla.org/en-US/docs/Web/CSS/text-size-adjust

Before/After on iOS Safari:
<table>
  <tr>
    <td>
      <img src="https://github.com/user-attachments/assets/b7ad03b0-4613-4af3-9e34-35b4a98b1dcf" alt="IMG_8068" width="300">
    </td>
    <td>
      <img src="https://github.com/user-attachments/assets/f77fa0e4-5247-4231-a429-5443a89d64a2" alt="IMG_8069" width="300">
    </td>
  </tr>
</table>


